### PR TITLE
8284907: Compact profiles build fails with GNU make 4

### DIFF
--- a/jdk/make/CreateJars.gmk
+++ b/jdk/make/CreateJars.gmk
@@ -309,6 +309,15 @@ $(BEANLESS_CLASSES)/%: $(JDK_OUTPUTDIR)/classes/%
 	$(MKDIR) -p $(@D)
 	$(TOOL_REMOVEMETHODS) '$<' $@ addPropertyChangeListener removePropertyChangeListener
 
+# Code these targets explicitly because the target "%" expansion does
+# not work with the inline "$" in the file name.
+$(BEANLESS_CLASSES)/java/util/jar/Pack200\$$Packer.class: $(JDK_OUTPUTDIR)/classes/java/util/jar/Pack200$$Packer.class
+	$(MKDIR) -p $(@D)
+	$(TOOL_REMOVEMETHODS) '$<' $@ addPropertyChangeListener removePropertyChangeListener
+ $(BEANLESS_CLASSES)/java/util/jar/Pack200\$$Unpacker.class: $(JDK_OUTPUTDIR)/classes/java/util/jar/Pack200$$Unpacker.class
+	$(MKDIR) -p $(@D)
+	$(TOOL_REMOVEMETHODS) '$<' $@ addPropertyChangeListener removePropertyChangeListener
+
 CLASSES_TO_DEBEAN = \
     java/util/logging/LogManager.class \
     java/util/jar/Pack200\$$Packer.class \


### PR DESCRIPTION
The compact profiles jar creation logic relies on what seems to be undefined behavior in GNU make. Pattern rules are unreliable when the file names contain '$'. The specific construct used in CreateJars.gmk works with GNU make 3.81, but fails with version 4 or higher.

This was originally fixed in 8u60 in [JDK-8067857](https://bugs.openjdk.java.net/browse/JDK-8067857). That change is quite big and not something we want to backport to 8u42. However, since then, GNU make 4 and higher have become quite common on Linux too, and not just in Cygwin where I believe this problem was first encountered. Because of this, I would like to extract just the fix for this, exactly as it was done in [JDK-8067857](https://bugs.openjdk.java.net/browse/JDK-8067857). Here is the original change:

https://github.com/openjdk/jdk8u-dev/commit/17421c860a6e71e14b0023e686b87c35b2049f69#diff-e580e7e55e76622c538ae8a1b55af984b3e12bba099e493582fff2925b9ae02aR314-R322

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284907](https://bugs.openjdk.java.net/browse/JDK-8284907): Compact profiles build fails with GNU make 4


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-ri pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.java.net/jdk8u-ri pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-ri/pull/2.diff">https://git.openjdk.java.net/jdk8u-ri/pull/2.diff</a>

</details>
