### PR TITLE
8175797: (ref) Reference::enqueue method should clear the reference object before enqueuing

### DIFF
--- a/jdk/src/share/classes/java/lang/ref/FinalReference.java
+++ b/jdk/src/share/classes/java/lang/ref/FinalReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,5 +32,10 @@ class FinalReference<T> extends Reference<T> {
 
     public FinalReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);
+    }
+
+    @Override
+    public boolean enqueue() {
+        throw new InternalError("should never reach here");
     }
 }

--- a/jdk/src/share/classes/java/lang/ref/Reference.java
+++ b/jdk/src/share/classes/java/lang/ref/Reference.java
@@ -213,7 +213,6 @@ public abstract class Reference<T> {
         this.referent = null;
     }
 
-
     /* -- Queue operations -- */
 
     /**
@@ -230,8 +229,8 @@ public abstract class Reference<T> {
     }
 
     /**
-     * Adds this reference object to the queue with which it is registered,
-     * if any.
+     * Clears this reference object and adds it to the queue with which
+     * it is registered, if any.
      *
      * <p> This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
@@ -241,9 +240,9 @@ public abstract class Reference<T> {
      *           it was not registered with a queue when it was created
      */
     public boolean enqueue() {
+        this.referent = null;
         return this.queue.enqueue(this);
     }
-
 
     /* -- Constructors -- */
 
@@ -255,5 +254,4 @@ public abstract class Reference<T> {
         this.referent = referent;
         this.queue = (queue == null) ? ReferenceQueue.NULL : queue;
     }
-
 }


### PR DESCRIPTION
These changes backport the following fixes to jdk8u-ri:

- 8175797: (ref) Reference::enqueue method should clear the reference object before enqueuing
- 8178832: (ref) jdk.lang.ref.disableClearBeforeEnqueue property is ignored
- 8193780: (ref) Remove the undocumented jdk.lang.ref.disableClearBeforeEnqueue system property

With this fix, the enqueue method clears the reference before enqueuing it to the registered queue.

The backport of changes to the file _jdk/test/java/lang/ref/ReferenceEnqueue.java_ needed some manual adjustment. Apart from that,  backport of changes to the rest of the files are exact match with the original fixes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8175797](https://bugs.openjdk.java.net/browse/JDK-8175797): (ref) Reference::enqueue method should clear the reference object before enqueuing ⚠️ Issue is not open.
 * [JDK-8178832](https://bugs.openjdk.java.net/browse/JDK-8178832): (ref) jdk.lang.ref.disableClearBeforeEnqueue property is ignored ⚠️ Issue is not open.
 * [JDK-8193780](https://bugs.openjdk.java.net/browse/JDK-8193780): (ref) Remove the undocumented "jdk.lang.ref.disableClearBeforeEnqueue" system property ⚠️ Issue is not open.


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - no project role)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-ri pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.java.net/jdk8u-ri pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-ri/pull/5.diff">https://git.openjdk.java.net/jdk8u-ri/pull/5.diff</a>

</details>
