### PR TITLE
8201793: (ref) Reference object should not support cloning

### DIFF
--- a/jdk/src/share/classes/java/lang/ref/Reference.java
+++ b/jdk/src/share/classes/java/lang/ref/Reference.java
@@ -245,6 +245,20 @@ public abstract class Reference<T> {
     }
 
 
+    /**
+     * Throws {@link CloneNotSupportedException}. A {@code Reference} cannot be
+     * meaningfully cloned. Construct a new {@code Reference} instead.
+     *
+     * @returns never returns normally
+     * @throws  CloneNotSupportedException always
+     *
+     * @since 8
+     */
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        throw new CloneNotSupportedException();
+    }
+
     /* -- Constructors -- */
 
     Reference(T referent) {

--- a/jdk/src/share/classes/java/lang/ref/Reference.java
+++ b/jdk/src/share/classes/java/lang/ref/Reference.java
@@ -249,7 +249,9 @@ public abstract class Reference<T> {
      * Throws {@link CloneNotSupportedException}. A {@code Reference} cannot be
      * meaningfully cloned. Construct a new {@code Reference} instead.
      *
-     * @returns never returns normally
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 4.
+     *
+     * @return  never returns normally
      * @throws  CloneNotSupportedException always
      *
      * @since 8

--- a/jdk/test/java/lang/ref/ReferenceClone.java
+++ b/jdk/test/java/lang/ref/ReferenceClone.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8201793
+ * @summary Test Reference::clone to throw CloneNotSupportedException
+ */
+
+import java.lang.ref.*;
+
+public class ReferenceClone {
+    private static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
+    public static void main(String... args) {
+        ReferenceClone refClone = new ReferenceClone();
+        refClone.test();
+    }
+
+    public void test() {
+        // test Reference::clone that throws CNSE
+        Object o = new Object();
+        assertCloneNotSupported(new SoftRef(o));
+        assertCloneNotSupported(new WeakRef(o));
+        assertCloneNotSupported(new PhantomRef(o));
+
+        // Reference subclass may override the clone method
+        CloneableReference ref = new CloneableReference(o);
+        try {
+            ref.clone();
+        } catch (CloneNotSupportedException e) {}
+    }
+
+    private void assertCloneNotSupported(CloneableRef ref) {
+        try {
+            ref.clone();
+            throw new RuntimeException("Reference::clone should throw CloneNotSupportedException");
+        } catch (CloneNotSupportedException e) {}
+    }
+
+    // override clone to be public that throws CNSE
+    interface CloneableRef extends Cloneable {
+        public Object clone() throws CloneNotSupportedException;
+    }
+
+    class SoftRef extends SoftReference<Object> implements CloneableRef {
+        public SoftRef(Object referent) {
+            super(referent, QUEUE);
+        }
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    class WeakRef extends WeakReference<Object> implements CloneableRef {
+        public WeakRef(Object referent) {
+            super(referent, QUEUE);
+        }
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    class PhantomRef extends PhantomReference<Object> implements CloneableRef {
+        public PhantomRef(Object referent) {
+            super(referent, QUEUE);
+        }
+
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    // override clone to return a new instance
+    class CloneableReference extends WeakReference<Object> implements Cloneable {
+        public CloneableReference(Object referent) {
+            super(referent, QUEUE);
+        }
+
+        public Object clone() throws CloneNotSupportedException {
+            return new CloneableReference(this.get());
+        }
+    }
+
+}


### PR DESCRIPTION
This changeset backports the fix for 8201793 to jdk8u-ri.

With this change, `java.lang.ref.Reference::clone` method always throws `CloneNotSupportedException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8201793](https://bugs.openjdk.java.net/browse/JDK-8201793): (ref) Reference object should not support cloning
 * [JDK-8202260](https://bugs.openjdk.java.net/browse/JDK-8202260): (ref) Reference objects should not support cloning (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to a09669412cd59132cfcdd7089f16688f4b84b335
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - no project role) ⚠️ Review applies to 365622e17ebd5ae38bccddc39a6232e56826053e
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - Author) ⚠️ Review applies to a09669412cd59132cfcdd7089f16688f4b84b335


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-ri pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jdk8u-ri pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-ri/pull/6.diff">https://git.openjdk.java.net/jdk8u-ri/pull/6.diff</a>

</details>
