### PR TITLE
8285400: Add '@apiNote' to the APIs defined in Java SE 8 MR 3

### DIFF
--- a/jdk/src/share/classes/java/security/Signature.java
+++ b/jdk/src/share/classes/java/security/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/Signature.java
+++ b/jdk/src/share/classes/java/security/Signature.java
@@ -584,7 +584,6 @@ public abstract class Signature extends SignatureSpi {
      * supposed to be used for digital signatures, an
      * {@code InvalidKeyException} is thrown.
      *
-     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param certificate the certificate of the identity whose signature is
      * going to be verified.
      * @param params the parameters used for verifying this signature.
@@ -593,8 +592,6 @@ public abstract class Signature extends SignatureSpi {
      * is not encoded properly or does not include required  parameter
      * information or cannot be used for digital signature purposes.
      * @exception InvalidAlgorithmParameterException if the params is invalid.
-     *
-     * @since 8
      */
     final void initVerify(Certificate certificate,
             AlgorithmParameterSpec params)

--- a/jdk/src/share/classes/java/security/Signature.java
+++ b/jdk/src/share/classes/java/security/Signature.java
@@ -584,6 +584,7 @@ public abstract class Signature extends SignatureSpi {
      * supposed to be used for digital signatures, an
      * {@code InvalidKeyException} is thrown.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param certificate the certificate of the identity whose signature is
      * going to be verified.
      * @param params the parameters used for verifying this signature.

--- a/jdk/src/share/classes/java/security/interfaces/RSAKey.java
+++ b/jdk/src/share/classes/java/security/interfaces/RSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/interfaces/RSAKey.java
+++ b/jdk/src/share/classes/java/security/interfaces/RSAKey.java
@@ -56,6 +56,7 @@ public interface RSAKey {
      * explicitly specified or implicitly created during
      * key pair generation.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The default implementation returns {@code null}.
      *

--- a/jdk/src/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -98,12 +98,18 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The MGF1ParameterSpec which uses SHA-512/224 message digest
+     *
+     * @apiNote This field is defined in Java SE 8 Maintenance Release 3.
+     * @since 8
      */
     public static final MGF1ParameterSpec SHA512_224 =
         new MGF1ParameterSpec("SHA-512/224");
 
     /**
      * The MGF1ParameterSpec which uses SHA-512/256 message digest
+     *
+     * @apiNote This field is defined in Java SE 8 Maintenance Release 3.
+     * @since 8
      */
     public static final MGF1ParameterSpec SHA512_256 =
         new MGF1ParameterSpec("SHA-512/256");

--- a/jdk/src/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/PSSParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/PSSParameterSpec.java
@@ -96,6 +96,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
     /**
      * The {@code TrailerFieldBC} constant as defined in PKCS#1
      *
+     * @apiNote This field is defined in Java SE 8 Maintenance Release 3.
      * @since 8
      */
     public static final int TRAILER_FIELD_BC = 1;

--- a/jdk/src/share/classes/java/security/spec/RSAKeyGenParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAKeyGenParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/RSAKeyGenParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAKeyGenParameterSpec.java
@@ -70,6 +70,7 @@ public class RSAKeyGenParameterSpec implements AlgorithmParameterSpec {
      * Constructs a new {@code RSAKeyGenParameterSpec} object from the
      * given keysize, public-exponent value, and key parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param keysize the modulus size (specified in number of bits)
      * @param publicExponent the public exponent
      * @param keyParams the key parameters, may be null
@@ -103,6 +104,7 @@ public class RSAKeyGenParameterSpec implements AlgorithmParameterSpec {
     /**
      * Returns the parameters to be associated with key.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return the associated parameters, may be null if
      *         not present
      * @since 8

--- a/jdk/src/share/classes/java/security/spec/RSAMultiPrimePrivateCrtKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAMultiPrimePrivateCrtKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/RSAMultiPrimePrivateCrtKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAMultiPrimePrivateCrtKeySpec.java
@@ -104,6 +104,7 @@ public class RSAMultiPrimePrivateCrtKeySpec extends RSAPrivateKeySpec {
     * are copied to protect against subsequent modification when
     * constructing this object.
     *
+    * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
     * @param modulus          the modulus n
     * @param publicExponent   the public exponent e
     * @param privateExponent  the private exponent d

--- a/jdk/src/share/classes/java/security/spec/RSAPrivateCrtKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPrivateCrtKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/RSAPrivateCrtKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPrivateCrtKeySpec.java
@@ -81,6 +81,7 @@ public class RSAPrivateCrtKeySpec extends RSAPrivateKeySpec {
     * Creates a new {@code RSAPrivateCrtKeySpec} with additional
     * key parameters.
     *
+    * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
     * @param modulus the modulus n
     * @param publicExponent the public exponent e
     * @param privateExponent the private exponent d

--- a/jdk/src/share/classes/java/security/spec/RSAPrivateKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPrivateKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/RSAPrivateKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPrivateKeySpec.java
@@ -60,6 +60,7 @@ public class RSAPrivateKeySpec implements KeySpec {
     /**
      * Creates a new RSAPrivateKeySpec with additional key parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param modulus the modulus
      * @param privateExponent the private exponent
      * @param params the parameters associated with this key, may be null
@@ -94,6 +95,7 @@ public class RSAPrivateKeySpec implements KeySpec {
      * Returns the parameters associated with this key, may be null if not
      * present.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return the parameters associated with this key
      * @since 8
      */

--- a/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
@@ -60,6 +60,7 @@ public class RSAPublicKeySpec implements KeySpec {
     /**
      * Creates a new RSAPublicKeySpec with additional key parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param modulus the modulus
      * @param publicExponent the public exponent
      * @param params the parameters associated with this key, may be null
@@ -95,6 +96,7 @@ public class RSAPublicKeySpec implements KeySpec {
      * Returns the parameters associated with this key, may be null if not
      * present.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return the parameters associated with this key
      * @since 8
      */

--- a/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
@@ -1265,6 +1265,7 @@ public abstract class SSLEngine {
      * Application-Layer Protocol Negotiation (ALPN), can negotiate
      * application-level values between peers.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -1290,6 +1291,7 @@ public abstract class SSLEngine {
      * a connection may be in the middle of a handshake. The
      * application protocol may or may not yet be available.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -1350,8 +1352,9 @@ public abstract class SSLEngine {
      *         });
      * }</pre>
      *
-     * @apiNote
-     * This method should be called by TLS server applications before the TLS
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
+     *
+     * It should be called by TLS server applications before the TLS
      * handshake begins. Also, this {@code SSLEngine} should be configured with
      * parameters that are compatible with the application protocol selected by
      * the callback function. For example, enabling a poor choice of cipher
@@ -1380,6 +1383,7 @@ public abstract class SSLEngine {
      * setHandshakeApplicationProtocolSelector}
      * for the function's type parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.

--- a/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
@@ -1353,8 +1353,8 @@ public abstract class SSLEngine {
      * }</pre>
      *
      * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
-     *
-     * It should be called by TLS server applications before the TLS
+     * <p>
+     * This method should be called by TLS server applications before the TLS
      * handshake begins. Also, this {@code SSLEngine} should be configured with
      * parameters that are compatible with the application protocol selected by
      * the callback function. For example, enabling a poor choice of cipher

--- a/jdk/src/share/classes/javax/net/ssl/SSLParameters.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/javax/net/ssl/SSLParameters.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLParameters.java
@@ -486,6 +486,7 @@ public class SSLParameters {
      * <p>
      * This method will return a new array each time it is invoked.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return a non-null, possibly zero-length array of application protocol
      *         {@code String}s.  The array is ordered based on protocol
      *         preference, with {@code protocols[0]} being the most preferred.
@@ -518,6 +519,7 @@ public class SSLParameters {
      * action to take.  (For example, ALPN will send a
      * {@code "no_application_protocol"} alert and terminate the connection.)
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * This method will make a copy of the {@code protocols} array.
      *

--- a/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
@@ -763,8 +763,8 @@ public abstract class SSLSocket extends Socket
      * }</pre>
      *
      * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
-     *
-     * It should be called by TLS server applications before the TLS
+     * <p>
+     * This method should be called by TLS server applications before the TLS
      * handshake begins. Also, this {@code SSLSocket} should be configured with
      * parameters that are compatible with the application protocol selected by
      * the callback function. For example, enabling a poor choice of cipher

--- a/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
@@ -674,6 +674,7 @@ public abstract class SSLSocket extends Socket
      * Application-Layer Protocol Negotiation (ALPN), can negotiate
      * application-level values between peers.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -699,6 +700,7 @@ public abstract class SSLSocket extends Socket
      * a connection may be in the middle of a handshake. The
      * application protocol may or may not yet be available.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -760,8 +762,9 @@ public abstract class SSLSocket extends Socket
      *         });
      * }</pre>
      *
-     * @apiNote
-     * This method should be called by TLS server applications before the TLS
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
+     *
+     * It should be called by TLS server applications before the TLS
      * handshake begins. Also, this {@code SSLSocket} should be configured with
      * parameters that are compatible with the application protocol selected by
      * the callback function. For example, enabling a poor choice of cipher
@@ -789,6 +792,7 @@ public abstract class SSLSocket extends Socket
      * setHandshakeApplicationProtocolSelector}
      * for the function's type parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.


### PR DESCRIPTION
This change adds "apiNote This method is defined in Java SE 8 Maintenance Release 3." to the doc comments of the new APIs added with the following changesets in Java SE MR3 :

1. https://hg.openjdk.java.net/jdk8u/jdk8u41/jdk/rev/b26b096d4c89
2. https://hg.openjdk.java.net/jdk8u/jdk8u41/jdk/rev/6bada58189de

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285400](https://bugs.openjdk.java.net/browse/JDK-8285400): Add '@apiNote' to the APIs defined in Java SE 8 MR 3


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 7cdcb51c6228ac4107817f2e6dc88c65d3262e60
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to 7cdcb51c6228ac4107817f2e6dc88c65d3262e60


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-ri pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.java.net/jdk8u-ri pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-ri/pull/7.diff">https://git.openjdk.java.net/jdk8u-ri/pull/7.diff</a>

</details>
