### PR TITLE
JDK-8285497: Add system property for Java SE specification maintenance version

### DIFF
--- a/jdk/src/share/classes/java/lang/System.java
+++ b/jdk/src/share/classes/java/lang/System.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -557,6 +557,10 @@ public final class System {
      *     <td>Java installation directory</td></tr>
      * <tr><td><code>java.vm.specification.version</code></td>
      *     <td>Java Virtual Machine specification version</td></tr>
+     * <tr><td><code>java.specification.maintenance.version</code></td>
+     *     <td>Java Runtime Environment specification maintenance
+     *     version, may be interpreted as a positive integer
+     *     <em>(optional, see below)</em></td></tr>
      * <tr><td><code>java.vm.specification.vendor</code></td>
      *     <td>Java Virtual Machine specification vendor</td></tr>
      * <tr><td><code>java.vm.specification.name</code></td>
@@ -607,6 +611,16 @@ public final class System {
      * <tr><td><code>user.dir</code></td>
      *     <td>User's current working directory</td></tr>
      * </table>
+     * <p>
+     * The {@code java.specification.maintenance.version} property is
+     * defined if the specification implemented by this runtime at the
+     * time of its construction had undergone a <a
+     * href="https://jcp.org/en/procedures/jcp2#3.6.4">maintenance
+     * release</a>. When defined, its value identifies that
+     * maintenance release. To indicate the first maintenance release
+     * this property will have the value {@code "1"}, to indicate the
+     * second maintenance release this property will have the value
+     * {@code "2"}, and so on.
      * <p>
      * Multiple paths in a system property value are separated by the path
      * separator character of the platform.

--- a/jdk/src/share/classes/sun/security/provider/PolicyFile.java
+++ b/jdk/src/share/classes/sun/security/provider/PolicyFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,6 +683,9 @@ public class PolicyFile extends java.security.Policy {
                     SecurityConstants.PROPERTY_READ_ACTION));
                 pe.add(new PropertyPermission
                                 ("java.specification.version",
+                                    SecurityConstants.PROPERTY_READ_ACTION));
+                pe.add(new PropertyPermission
+                                ("java.specification.maintenance.version",
                                     SecurityConstants.PROPERTY_READ_ACTION));
                 pe.add(new PropertyPermission
                                 ("java.specification.vendor",

--- a/jdk/src/share/lib/security/java.policy
+++ b/jdk/src/share/lib/security/java.policy
@@ -36,6 +36,7 @@ grant {
         permission java.util.PropertyPermission "line.separator", "read";
 
         permission java.util.PropertyPermission "java.specification.version", "read";
+        permission java.util.PropertyPermission "java.specification.maintenance.version", "read";
         permission java.util.PropertyPermission "java.specification.vendor", "read";
         permission java.util.PropertyPermission "java.specification.name", "read";
 

--- a/jdk/src/share/native/java/lang/System.c
+++ b/jdk/src/share/native/java/lang/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,6 +189,8 @@ Java_java_lang_System_initProperties(JNIEnv *env, jclass cla, jobject props)
 
     PUTPROP(props, "java.specification.version",
             JDK_MAJOR_VERSION "." JDK_MINOR_VERSION);
+    PUTPROP(props, "java.specification.maintenance.version",
+            "4");
     PUTPROP(props, "java.specification.name",
             "Java Platform API Specification");
     PUTPROP(props, "java.specification.vendor",


### PR DESCRIPTION
Backport of change from JDK 19.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8285497](https://bugs.openjdk.java.net/browse/JDK-8285497): Add system property for Java SE specification maintenance version ⚠️ Issue is not open.
 * [JDK-8285764](https://bugs.openjdk.java.net/browse/JDK-8285764): Add system property for Java SE specification maintenance version (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - Author)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-ri pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jdk8u-ri pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-ri/pull/8.diff">https://git.openjdk.java.net/jdk8u-ri/pull/8.diff</a>

</details>
